### PR TITLE
feat: Time Table Custom setting & slot random color

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,8 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "import/prefer-default-export": "off", //파일에서 export를 하나만 할때 default export를 쓰라고 하는 eslint off
-    "no-confusing-arrow": ["error", { "allowParens": true, "onlyOneSimpleParam": true }]
+    "no-confusing-arrow": ["error", { "allowParens": true, "onlyOneSimpleParam": true }],
+    "react/require-default-props": "off"
   },
   "settings": {
     "react": {

--- a/src/app/timetable/components/Slot.tsx
+++ b/src/app/timetable/components/Slot.tsx
@@ -9,17 +9,28 @@ interface SlotProps {
   taskItemList: Task[];
   height: string;
   shouldDisplayTaskContentList: boolean[];
+  timeSlotStyle: React.CSSProperties;
+  taskSlotStyle: React.CSSProperties;
 }
 
-function Slot({ headerDate, slotTime, taskItemList, height, shouldDisplayTaskContentList = [] }: SlotProps) {
+function Slot({
+  headerDate,
+  slotTime,
+  taskItemList,
+  height,
+  shouldDisplayTaskContentList = [],
+  timeSlotStyle,
+  taskSlotStyle,
+}: SlotProps) {
   return (
     <div className={styled.slot} style={{ height }}>
-      <TimeSlot headerDate={headerDate} />
+      <TimeSlot headerDate={headerDate} timeSlotStyle={timeSlotStyle} />
       <TaskSlot
         headerDate={headerDate}
         slotTime={slotTime}
         taskItemList={taskItemList}
         shouldDisplayTaskContentList={shouldDisplayTaskContentList}
+        taskSlotStyle={taskSlotStyle}
       />
     </div>
   );

--- a/src/app/timetable/components/TaskSlot.tsx
+++ b/src/app/timetable/components/TaskSlot.tsx
@@ -1,5 +1,5 @@
 import { add } from 'date-fns';
-import { calculateTaskOffsetAndHeightPercent } from '../utils';
+import { calculateTaskOffsetAndHeightPercent, getColor } from '../utils';
 import styled from './Slot.module.scss';
 import type { Task } from './Timetable.type';
 
@@ -21,7 +21,7 @@ function TaskSlot({ headerDate, slotTime, taskItemList, shouldDisplayTaskContent
   return (
     <div className={styled.taskSlotLayout}>
       {taskItemList.map((taskItem, index) => {
-        const { startTime, endTime, slotColor, title, subTitle } = taskItem;
+        const { startTime, endTime, slotColor: taskColor, title, subTitle, id } = taskItem;
         const { offsetPercent, heightPercent } = calculateTaskOffsetAndHeightPercent(
           slotStartTime,
           slotEndTime,
@@ -31,6 +31,10 @@ function TaskSlot({ headerDate, slotTime, taskItemList, shouldDisplayTaskContent
         );
         const shouldDisplayTaskContent = shouldDisplayTaskContentList[index];
         const key = `${startTime.toDateString()}${endTime.toDateString()}${title}${subTitle}`;
+        const slotColor = taskColor ?? getColor(id);
+
+        console.log(`taskItem: ${taskItem}`);
+        console.log(`slotColor ${slotColor}`);
 
         return (
           <div key={key}>

--- a/src/app/timetable/components/TaskSlot.tsx
+++ b/src/app/timetable/components/TaskSlot.tsx
@@ -21,7 +21,7 @@ function TaskSlot({ headerDate, slotTime, taskItemList, shouldDisplayTaskContent
   return (
     <div className={styled.taskSlotLayout}>
       {taskItemList.map((taskItem, index) => {
-        const { startTime, endTime, slotColor: taskColor, title, subTitle, id } = taskItem;
+        const { startTime, endTime, taskColor, title, subTitle, id } = taskItem;
         const { offsetPercent, heightPercent } = calculateTaskOffsetAndHeightPercent(
           slotStartTime,
           slotEndTime,

--- a/src/app/timetable/components/TaskSlot.tsx
+++ b/src/app/timetable/components/TaskSlot.tsx
@@ -33,9 +33,6 @@ function TaskSlot({ headerDate, slotTime, taskItemList, shouldDisplayTaskContent
         const key = `${startTime.toDateString()}${endTime.toDateString()}${title}${subTitle}`;
         const slotColor = taskColor ?? getColor(id);
 
-        console.log(`taskItem: ${taskItem}`);
-        console.log(`slotColor ${slotColor}`);
-
         return (
           <div key={key}>
             <div

--- a/src/app/timetable/components/TaskSlot.tsx
+++ b/src/app/timetable/components/TaskSlot.tsx
@@ -8,9 +8,10 @@ interface TaskSlotProps {
   slotTime: number;
   taskItemList: Task[];
   shouldDisplayTaskContentList: boolean[];
+  taskSlotStyle: React.CSSProperties;
 }
 
-function TaskSlot({ headerDate, slotTime, taskItemList, shouldDisplayTaskContentList }: TaskSlotProps) {
+function TaskSlot({ headerDate, slotTime, taskItemList, shouldDisplayTaskContentList, taskSlotStyle = {} }: TaskSlotProps) {
   if (taskItemList.length === 0) {
     return <div className={styled.taskSlotLayout} />;
   }
@@ -19,7 +20,7 @@ function TaskSlot({ headerDate, slotTime, taskItemList, shouldDisplayTaskContent
   const slotEndTime = add(headerDate, { minutes: slotTime });
 
   return (
-    <div className={styled.taskSlotLayout}>
+    <div className={styled.taskSlotLayout} style={taskSlotStyle}>
       {taskItemList.map((taskItem, index) => {
         const { startTime, endTime, taskColor, title, subTitle, id } = taskItem;
         const { offsetPercent, heightPercent } = calculateTaskOffsetAndHeightPercent(

--- a/src/app/timetable/components/TimeSlot.tsx
+++ b/src/app/timetable/components/TimeSlot.tsx
@@ -3,12 +3,13 @@ import styled from './Slot.module.scss';
 
 interface TimeSlotProps {
   headerDate: Date;
+  timeSlotStyle: React.CSSProperties;
 }
 
-function TimeSlot({ headerDate }: TimeSlotProps) {
+function TimeSlot({ headerDate, timeSlotStyle }: TimeSlotProps) {
   const currentTime = getHourAndMinutesFormat(headerDate);
   return (
-    <div className={`${styled.timeSlotLayout} ${styled.title}`}>
+    <div className={`${styled.timeSlotLayout} ${styled.title}`} style={timeSlotStyle}>
       <p className={styled.headerDate}>{currentTime}</p>
     </div>
   );

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -66,7 +66,7 @@ function Timetable({
 
   return (
     <div>
-      <div className={styled.container} style={{ height, ...style }}>
+      <div className={styled.container} style={{ ...style, height }}>
         {displayCurrentTime && <CurrentTimeLine timeSlots={timeSlots.length} startTime={startTime} endTime={endTime} />}
         {timeSlots.map((time: Date, index) => {
           const key = `${time.toDateString()}${index}`;

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -6,7 +6,6 @@ import { parseHeight, distributeHeight, hasKey, insertKey, checkTimeOverlapFromT
 import styled from './Timetable.module.scss';
 import Slot from './Slot';
 import CurrentTimeLine from './CurrentTimeLine';
-import { Style } from './Timetable.type';
 
 interface TimetableProps {
   startTime: Date;
@@ -16,7 +15,7 @@ interface TimetableProps {
   timetableType: 'CURCLE' | 'ROW' | 'COLUMN';
   displayCurrentTime?: boolean;
   taskList: Task[];
-  style?: Style;
+  style?: React.CSSProperties;
 }
 
 interface Task {
@@ -49,7 +48,7 @@ function Timetable({
   timetableType,
   displayCurrentTime = false,
   taskList,
-  style = { color: 'black', backgroundColor: 'white' },
+  style = { color: 'white', backgroundColor: 'white' },
 }: TimetableProps) {
   console.log(timetableType);
 
@@ -62,7 +61,6 @@ function Timetable({
     throw new Error('task time is overlap. please check your taskList');
   }
 
-  const { color, backgroundColor } = style!;
   const timeSlots = eachMinuteOfInterval(
     {
       start: startTime,
@@ -76,7 +74,7 @@ function Timetable({
 
   return (
     <div>
-      <div className={styled.container} style={{ height, color, backgroundColor }}>
+      <div className={styled.container} style={{ height, ...style }}>
         {displayCurrentTime && <CurrentTimeLine timeSlots={timeSlots.length} startTime={startTime} endTime={endTime} />}
         {timeSlots.map((time: Date, index) => {
           const key = `${time.toDateString()}${index}`;

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -6,6 +6,7 @@ import { parseHeight, distributeHeight, hasKey, insertKey, checkTimeOverlapFromT
 import styled from './Timetable.module.scss';
 import Slot from './Slot';
 import CurrentTimeLine from './CurrentTimeLine';
+import { Task } from './Timetable.type';
 
 interface TimetableProps {
   startTime: Date;
@@ -16,15 +17,6 @@ interface TimetableProps {
   displayCurrentTime?: boolean;
   taskList: Task[];
   style?: React.CSSProperties;
-}
-
-interface Task {
-  id: number;
-  title: string;
-  subTitle: string;
-  slotColor: string;
-  startTime: Date;
-  endTime: Date;
 }
 
 const taskListFilter = (taskListInput: Task[], checkHour: number, slotTimeInput: number) =>

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -104,11 +104,3 @@ function Timetable({
 }
 
 export default Timetable;
-
-Timetable.defaultProps = {
-  displayCurrentTime: false,
-  style: {
-    color: 'black',
-    backgroundColor: 'white',
-  },
-};

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -16,7 +16,9 @@ interface TimetableProps {
   timetableType: 'CURCLE' | 'ROW' | 'COLUMN';
   displayCurrentTime?: boolean;
   taskList: Task[];
-  style?: React.CSSProperties;
+  timeTableStyle?: React.CSSProperties;
+  timeSlotStyle?: React.CSSProperties;
+  taskSlotStyle?: React.CSSProperties;
 }
 
 const taskListFilter = (taskListInput: Task[], checkHour: number, slotTimeInput: number) =>
@@ -40,7 +42,9 @@ function Timetable({
   timetableType,
   displayCurrentTime = false,
   taskList,
-  style = { color: 'white', backgroundColor: 'white' },
+  timeTableStyle = { backgroundColor: 'white' },
+  timeSlotStyle = { color: 'black' },
+  taskSlotStyle = { color: 'white' },
 }: TimetableProps) {
   console.log(timetableType);
 
@@ -66,7 +70,7 @@ function Timetable({
 
   return (
     <div>
-      <div className={styled.container} style={{ ...style, height }}>
+      <div className={styled.container} style={{ ...timeTableStyle, height }}>
         {displayCurrentTime && <CurrentTimeLine timeSlots={timeSlots.length} startTime={startTime} endTime={endTime} />}
         {timeSlots.map((time: Date, index) => {
           const key = `${time.toDateString()}${index}`;
@@ -85,6 +89,8 @@ function Timetable({
               taskItemList={taskItemList}
               height={slotHeight}
               shouldDisplayTaskContentList={shouldDisplayTaskContentList}
+              timeSlotStyle={timeSlotStyle}
+              taskSlotStyle={taskSlotStyle}
             />
           );
         })}

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -6,6 +6,7 @@ import { parseHeight, distributeHeight, hasKey, insertKey, checkTimeOverlapFromT
 import styled from './Timetable.module.scss';
 import Slot from './Slot';
 import CurrentTimeLine from './CurrentTimeLine';
+import { Style } from './Timetable.type';
 
 interface TimetableProps {
   startTime: Date;
@@ -13,8 +14,9 @@ interface TimetableProps {
   slotTime: number;
   height: string;
   timetableType: 'CURCLE' | 'ROW' | 'COLUMN';
-  displayCurrentTime: boolean;
+  displayCurrentTime?: boolean;
   taskList: Task[];
+  style?: Style;
 }
 
 interface Task {
@@ -39,7 +41,16 @@ const taskListFilter = (taskListInput: Task[], checkHour: number, slotTimeInput:
     );
   });
 
-function Timetable({ startTime, endTime, slotTime, height, timetableType, displayCurrentTime, taskList }: TimetableProps) {
+function Timetable({
+  startTime,
+  endTime,
+  slotTime,
+  height,
+  timetableType,
+  displayCurrentTime = false,
+  taskList,
+  style = { color: 'black', backgroundColor: 'white' },
+}: TimetableProps) {
   console.log(timetableType);
 
   const hasOverlapFromTaskList = useCallback(
@@ -51,6 +62,7 @@ function Timetable({ startTime, endTime, slotTime, height, timetableType, displa
     throw new Error('task time is overlap. please check your taskList');
   }
 
+  const { color, backgroundColor } = style!;
   const timeSlots = eachMinuteOfInterval(
     {
       start: startTime,
@@ -58,14 +70,13 @@ function Timetable({ startTime, endTime, slotTime, height, timetableType, displa
     },
     { step: slotTime },
   );
-
   const { value, format } = parseHeight(height);
   const slotHeight = distributeHeight(value, timeSlots.length, format);
   const uniqueTaskIdMap = new Map();
 
   return (
     <div>
-      <div className={styled.container} style={{ height }}>
+      <div className={styled.container} style={{ height, color, backgroundColor }}>
         {displayCurrentTime && <CurrentTimeLine timeSlots={timeSlots.length} startTime={startTime} endTime={endTime} />}
         {timeSlots.map((time: Date, index) => {
           const key = `${time.toDateString()}${index}`;
@@ -93,3 +104,11 @@ function Timetable({ startTime, endTime, slotTime, height, timetableType, displa
 }
 
 export default Timetable;
+
+Timetable.defaultProps = {
+  displayCurrentTime: false,
+  style: {
+    color: 'black',
+    backgroundColor: 'white',
+  },
+};

--- a/src/app/timetable/components/Timetable.type.ts
+++ b/src/app/timetable/components/Timetable.type.ts
@@ -2,7 +2,7 @@ interface Task {
   id: number;
   title: string;
   subTitle: string;
-  slotColor?: string;
+  taskColor?: string;
   startTime: Date;
   endTime: Date;
 }

--- a/src/app/timetable/components/Timetable.type.ts
+++ b/src/app/timetable/components/Timetable.type.ts
@@ -7,9 +7,4 @@ interface Task {
   endTime: Date;
 }
 
-interface Style {
-  color: string;
-  backgroundColor: string;
-}
-
-export type { Task, Style };
+export type { Task };

--- a/src/app/timetable/components/Timetable.type.ts
+++ b/src/app/timetable/components/Timetable.type.ts
@@ -7,4 +7,9 @@ interface Task {
   endTime: Date;
 }
 
-export type { Task };
+interface Style {
+  color: string;
+  backgroundColor: string;
+}
+
+export type { Task, Style };

--- a/src/app/timetable/components/Timetable.type.ts
+++ b/src/app/timetable/components/Timetable.type.ts
@@ -2,7 +2,7 @@ interface Task {
   id: number;
   title: string;
   subTitle: string;
-  slotColor: string;
+  slotColor?: string;
   startTime: Date;
   endTime: Date;
 }

--- a/src/app/timetable/constants/index.ts
+++ b/src/app/timetable/constants/index.ts
@@ -1,4 +1,4 @@
-const formatList = [
+const FORMAT_LIST = [
   'px',
   '%',
   'em',
@@ -19,6 +19,9 @@ const formatList = [
   'vi',
   'vb',
   'q',
-];
+] as const;
 
-export { formatList };
+type FormatType = (typeof FORMAT_LIST)[number];
+
+export { FORMAT_LIST };
+export type { FormatType };

--- a/src/app/timetable/constants/index.ts
+++ b/src/app/timetable/constants/index.ts
@@ -20,8 +20,24 @@ const FORMAT_LIST = [
   'vb',
   'q',
 ] as const;
-
 type FormatType = (typeof FORMAT_LIST)[number];
 
-export { FORMAT_LIST };
+const COLOR_LIST = [
+  '#FF5151',
+  '#88E0EF',
+  '#FCE38A',
+  '#161E54',
+  '#FF9B6A',
+  '#00D1CD',
+  '#FFE98A',
+  '#F30067',
+  '#EAEAEA',
+  '#280B45',
+  '#95E1D3',
+  '#61105E',
+  '#C84771',
+] as const;
+const COLOR_LIST_LENGTH = COLOR_LIST.length;
+
+export { FORMAT_LIST, COLOR_LIST, COLOR_LIST_LENGTH };
 export type { FormatType };

--- a/src/app/timetable/mocks/timetableMockData.ts
+++ b/src/app/timetable/mocks/timetableMockData.ts
@@ -91,4 +91,42 @@ const duplicatedTimeTaskList = [
   },
 ];
 
-export { startTime, endTime, taskList, duplicatedTimeTaskList, slotTime, height };
+const taskListWithoutSlotColor = [
+  {
+    id: 1,
+    title: 'title1',
+    subTitle: 'subTitle1',
+    startTime: getDateFromTime(12, 0, 0),
+    endTime: getDateFromTime(13, 0, 0),
+  },
+  {
+    id: 2,
+    title: 'title2',
+    subTitle: 'subTitle2',
+    startTime: getDateFromTime(15, 0, 0),
+    endTime: getDateFromTime(16, 0, 0),
+  },
+  {
+    id: 3,
+    title: 'title3',
+    subTitle: 'subTitle3',
+    startTime: getDateFromTime(18, 0, 0),
+    endTime: getDateFromTime(20, 0, 0),
+  },
+  {
+    id: 5,
+    title: '02:30',
+    subTitle: '02:50',
+    startTime: getDateFromTime(2, 30, 0),
+    endTime: getDateFromTime(2, 50, 0),
+  },
+  {
+    id: 4,
+    title: '01:00',
+    subTitle: '02:20',
+    startTime: getDateFromTime(1, 0, 0),
+    endTime: getDateFromTime(2, 20, 0),
+  },
+];
+
+export { startTime, endTime, taskList, duplicatedTimeTaskList, slotTime, height, taskListWithoutSlotColor };

--- a/src/app/timetable/utils/color.ts
+++ b/src/app/timetable/utils/color.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { COLOR_LIST, COLOR_LIST_LENGTH } from '../constants';
+
+let currentColorIndex = 0;
+const colorMatchMap = new Map<unknown, unknown>();
+
+const getColor = (id: unknown) => {
+  if (colorMatchMap.has(id)) {
+    return colorMatchMap.get(id);
+  }
+
+  currentColorIndex %= COLOR_LIST_LENGTH;
+  currentColorIndex += 1;
+  const color = COLOR_LIST[currentColorIndex];
+  colorMatchMap.set(id, color);
+  return color;
+};
+
+export { getColor };

--- a/src/app/timetable/utils/color.ts
+++ b/src/app/timetable/utils/color.ts
@@ -10,9 +10,8 @@ const getColor = (id: unknown) => {
     return colorMatchMap.get(id);
   }
 
-  currentColorIndex %= COLOR_LIST_LENGTH;
-  currentColorIndex += 1;
   const color = COLOR_LIST[currentColorIndex];
+  currentColorIndex = (currentColorIndex + 1) % COLOR_LIST_LENGTH;
   colorMatchMap.set(id, color);
   return color;
 };

--- a/src/app/timetable/utils/height.ts
+++ b/src/app/timetable/utils/height.ts
@@ -1,6 +1,6 @@
-import { formatList as properFormatList } from '../constants';
+import { FORMAT_LIST, FormatType } from '../constants';
 
-const isFormatString = (formatType: string) => properFormatList.includes(formatType);
+const isFormatString = (formatType: string): formatType is FormatType => FORMAT_LIST.includes(formatType as FormatType);
 
 const parseHeightFormat = (heightWithFormat: string) => {
   const formatList = heightWithFormat.match(/[a-z%]+/);

--- a/src/app/timetable/utils/index.ts
+++ b/src/app/timetable/utils/index.ts
@@ -85,3 +85,4 @@ export {
 };
 export { hasKey, insertKey } from './map';
 export { distributeHeight, isFormatString, parseHeight, parseHeightFormat, parseHeightValue } from './height';
+export { getColor } from './color';

--- a/src/app/timetable/utils/tests/parseHeightString.test.ts
+++ b/src/app/timetable/utils/tests/parseHeightString.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from '@jest/globals';
 import { parseHeightFormat, parseHeightValue } from '..';
-import { formatList } from '../../constants';
+import { FORMAT_LIST } from '../../constants';
 
 describe('Timetable의 height 값 나누기', () => {
   describe('height 값에서 format 가져오기', () => {
     const height = 1000;
 
-    formatList.forEach((format) => {
+    FORMAT_LIST.forEach((format) => {
       test(`height으로 ${height}${format} 이 주어졌을 때 ${format}을 분리할 수 있다.`, () => {
         // given
         const heightString = `${height}${format}`;
@@ -24,7 +24,7 @@ describe('Timetable의 height 값 나누기', () => {
     const heightValueList = [100, 95, 0.5, 48.33333, 3];
 
     heightValueList.forEach((heightValue) => {
-      formatList.forEach((format) => {
+      FORMAT_LIST.forEach((format) => {
         const height = `${heightValue}${format}`;
         test(`height으로 ${height}이 주어졌을 때 값 ${heightValue}을 분리할 수 있다.`, () => {
           // when


### PR DESCRIPTION
- Close #46 

## What is this PR? 🔍
- 기능 : 
1. TimeTable의 스타일을 사용자가 정의한 style이 적용되게 변경했습니다. 
(TimeTable,  TimeSlot, TaskSlot의 style을 각기 다르게 적용할 수 있습니다.)
2. task에 속성을 넣지 않아도 임의의 색상이 보이도록 수정했습니다.
- issue : #46 

## Changes 📝

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
### 사용자가 정의한 style
![스크린샷 2024-08-02 오후 3 33 58](https://github.com/user-attachments/assets/b0650b16-1d07-4366-99b9-4fe03c8fa46f)
![스크린샷 2024-08-02 오후 3 34 27](https://github.com/user-attachments/assets/c7fdd444-6c3f-46de-b124-cb41d4a0b573)




### 랜덤 컬러
![스크린샷 2024-08-02 오전 11 19 07](https://github.com/user-attachments/assets/e37b04f2-0b1d-40df-806d-892cfd162b60)
![스크린샷 2024-08-02 오전 11 29 08](https://github.com/user-attachments/assets/61a52c73-ee7d-4583-b30d-80b230b402ee)



<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
