### PR TITLE
fix: 실제 시간과 CurrentTimeLine의 차이 좁히기

### DIFF
--- a/src/app/timetable/components/CurrentTimeLine/CurrentTimeLine.module.scss
+++ b/src/app/timetable/components/CurrentTimeLine/CurrentTimeLine.module.scss
@@ -1,30 +1,30 @@
-.currentTimeLineColumn {
+.currentTimeLine {
   position: absolute;
-  width: 100%;
   display: flex;
   align-items: center;
   z-index: 1;
 
   .line {
-    width: 100%;
-    height: 1px;
     background-color: red;
     flex-grow: 1;
+    border: 1px solid red;
   }
-}
 
-.currentTimeLineRow {
-  position: absolute;
-
-  height: 100%;
-  display: flex;
-  align-items: center;
-  z-index: 1;
-
-  .line {
+  &.row {
     height: 100%;
-    width: 1px;
-    background-color: red;
-    flex-grow: 1;
+
+    .line {
+      height: 100%;
+      width: 1px;
+    }
+  }
+
+  &.column {
+    width: 100%;
+
+    .line {
+      width: 100%;
+      height: 1px;
+    }
   }
 }

--- a/src/app/timetable/components/CurrentTimeLine/index.tsx
+++ b/src/app/timetable/components/CurrentTimeLine/index.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 
 import styled from './CurrentTimeLine.module.scss';
-import { calculateCurrentTimeOffset, parseHeight } from '../../utils';
+import { calculateCurrentTimeOffset, parseHeight, generateClassNameWithType } from '../../utils';
 import TypeContext from '../../TypeContext';
 
 interface CurrentTimeLineProps {
@@ -13,7 +13,6 @@ interface CurrentTimeLineProps {
 function CurrentTimeLine({ startTime, endTime, height }: CurrentTimeLineProps) {
   const type = useContext(TypeContext);
   const [currentTime, setCurrentTime] = useState(new Date());
-
   const { value, format } = parseHeight(height);
 
   // 여기서 전체 offset을 정리해서 두자.
@@ -26,29 +25,12 @@ function CurrentTimeLine({ startTime, endTime, height }: CurrentTimeLineProps) {
   }, []);
 
   const { offsetPercent } = calculateCurrentTimeOffset(currentTime, startTime, endTime);
-  const test = (offsetPercent * value) / 100 + format;
-
-  const getCurrentTimeLineClass = () => {
-    if (type === 'ROW') {
-      return `${styled.currentTimeLineRow}`;
-    }
-    if (type === 'COLUMN') {
-      return `${styled.currentTimeLineColumn}`;
-    }
-    return styled.currentTimeLine;
-  };
-
-  const dynamicStyle: React.CSSProperties = {};
-
-  if (type === 'COLUMN') {
-    dynamicStyle.top = `${test}`;
-  } else if (type === 'ROW') {
-    dynamicStyle.left = `${test}`;
-  }
+  const currentTimeLinePosition = `${(offsetPercent * value) / 100}${format}`;
+  const dynamicStyle: React.CSSProperties = type === 'ROW' ? { left: currentTimeLinePosition } : { top: currentTimeLinePosition };
 
   return (
-    <div className={getCurrentTimeLineClass()} style={dynamicStyle}>
-      <div className={styled.line} />
+    <div className={generateClassNameWithType(styled, 'currentTimeLine', type)} style={dynamicStyle}>
+      <div className={generateClassNameWithType(styled, 'line', type)} />
     </div>
   );
 }

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -63,6 +63,8 @@ function Timetable({
         taskSlotStyle={taskSlotStyle}
         timeTableStyle={timeTableStyle}
         height={height}
+        startTime={startTime}
+        endTime={endTime}
       />
     </TypeContext.Provider>
   );

--- a/src/app/timetable/components/TypeTimeTable/index.tsx
+++ b/src/app/timetable/components/TypeTimeTable/index.tsx
@@ -11,11 +11,13 @@ interface TypeTimeTableProps {
   slotWidth: string;
   taskList: Task[];
   slotTime: number;
+  height: string;
+  startTime: Date;
+  endTime: Date;
   displayCurrentTime?: boolean;
   timeSlotStyle: React.CSSProperties;
   taskSlotStyle?: React.CSSProperties;
   timeTableStyle?: React.CSSProperties;
-  height: string;
 }
 
 const taskListFilter = (taskListInput: Task[], checkHour: number, slotTimeInput: number) =>
@@ -41,6 +43,8 @@ function TypeTimeTable({
   taskSlotStyle = {},
   timeTableStyle = {},
   height,
+  startTime,
+  endTime,
 }: TypeTimeTableProps) {
   const uniqueTaskIdMap = new Map();
   const type = useContext(TypeContext);
@@ -50,9 +54,7 @@ function TypeTimeTable({
   const isCurrentTimeVisible = timeSlots[0] <= currentTime && currentTime <= timeSlots[timeSlots.length - 1];
   return (
     <div className={generateClassNameWithType(styles, 'container', type)} style={timeTableStyle}>
-      {displayCurrentTime && isCurrentTimeVisible && (
-        <CurrentTimeLine startTime={timeSlots[0]} endTime={timeSlots[timeSlots.length - 1]} height={height} />
-      )}
+      {displayCurrentTime && isCurrentTimeVisible && <CurrentTimeLine startTime={startTime} endTime={endTime} height={height} />}
       {timeSlots.map((time, index) => {
         const key = `${time.toDateString()}${index}`;
         const taskItemList = taskListFilter(taskList, time.getHours(), slotTime);

--- a/src/app/timetable/utils/index.ts
+++ b/src/app/timetable/utils/index.ts
@@ -60,8 +60,12 @@ const isTimeOverlap = (startTime1: Date, endTime1: Date, startTime2: Date, endTi
 };
 
 const getDateFromTime = (hours: number, minutes: number, second: number) => {
-  const yearMonthDay = '2024-08-06';
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = (now.getMonth() + 1).toString().padStart(2, '0'); // Months are zero-indexed
+  const day = now.getDate().toString().padStart(2, '0');
 
+  const yearMonthDay = `${year}-${month}-${day}`;
   const hourFormat = hours < 10 ? `0${hours}` : hours;
   const minutesFormat = minutes < 10 ? `0${minutes}` : minutes;
   const secondeFormat = second < 10 ? `0${second}` : second;

--- a/src/app/timetable/utils/index.ts
+++ b/src/app/timetable/utils/index.ts
@@ -12,6 +12,14 @@ const getHourAndMinutesFormat = (data: Date) => {
 // 시간을 분단위로 바꿔버리고 더해주는 함수
 const sumHoursAndMinutes = (date: Date) => date.getHours() * 60 + date.getMinutes();
 
+const TimeToMilliseconds = (date: Date) => {
+  const hourToMilliseconds = date.getHours() * 60 * 60 * 1000;
+  const minutesToMilliseconds = date.getMinutes() * 60 * 1000;
+  const secondsToMilliseconds = date.getSeconds() * 1000;
+
+  return hourToMilliseconds + minutesToMilliseconds + secondsToMilliseconds;
+};
+
 const calculateTaskOffsetAndHeightPercent = (
   slotStartTime: Date,
   slotEndTime: Date,
@@ -76,13 +84,12 @@ const checkTimeOverlapFromTaskList = (taskList: Task[]) => {
   return false;
 };
 
-const calculateCurrentTimeOffset = (currentTime: Date, slotStartTime: Date, endTime: Date) => {
+const calculateCurrentTimeOffset = (currentTime: Date, startTime: Date, endTime: Date) => {
   let offsetPercent = 0;
-
-  const currentMinutes = sumHoursAndMinutes(currentTime); // 현재 시간
-  const slotStartMinutes = sumHoursAndMinutes(slotStartTime); // 슬롯의 시작 시간
-  const slotEndMinutes = sumHoursAndMinutes(endTime); // 슬롯의 종료 시간
-  offsetPercent = ((currentMinutes - slotStartMinutes) / (slotEndMinutes - slotStartMinutes)) * 100;
+  const currentMinutes = TimeToMilliseconds(currentTime); // 현재 시간
+  const startMinutes = TimeToMilliseconds(startTime); // 슬롯의 시작 시간
+  const endMinutes = TimeToMilliseconds(endTime); // 슬롯의 종료 시간
+  offsetPercent = ((currentMinutes - startMinutes) / (endMinutes - startMinutes)) * 100;
 
   return { offsetPercent };
 };


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍

- 기능 : CurrentTimeLine 컴포넌트가 실제 시간과 유사한 시간을 가리킵니다.
- issue : #70 

## Changes 📝
```
 <CurrentTimeLine startTime={timeSlots[0]} endTime={timeSlots[timeSlots.length - 1]} height={height} />
```

```
 <CurrentTimeLine startTime={startTime} endTime={endTime} height={height} />}
```

timeSlot의 값은 시작시간은 동일하지만 끝 시간의 경우 TimeTable의 endTime과 동일하지 않았습니다. 따라서 TimeTable 컴포넌트의 endTimed을 그대로 가져왔습니다.
```
endTime = YY/MM/DD 23:59:59
timeSlots[timeSlots.length - 1] =  YY/MM/DD 23:00:00
```
또한, 더 정확한 값을 위해 기존의 `sumHoursAndMinutes`(시간을 분단위로 바꿔버리고 더해주는 함수) 대신 `TimeToMilliseconds`(시분초를 밀리세컨드로 변환)를 사용하여 더 정확한 값을 측정했습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
