### PR TITLE
refactor: props명 변경 및 타임테이블에서 함수와 컴포넌트 분리

### DIFF
--- a/src/app/timetable/components/CurrentTimeLine/index.tsx
+++ b/src/app/timetable/components/CurrentTimeLine/index.tsx
@@ -7,13 +7,13 @@ import TypeContext from '../../TypeContext';
 interface CurrentTimeLineProps {
   startTime: Date;
   endTime: Date;
-  height: string;
+  size: string;
 }
 
-function CurrentTimeLine({ startTime, endTime, height }: CurrentTimeLineProps) {
+function CurrentTimeLine({ startTime, endTime, size }: CurrentTimeLineProps) {
   const type = useContext(TypeContext);
   const [currentTime, setCurrentTime] = useState(new Date());
-  const { value, format } = parseSize(height);
+  const { value, format } = parseSize(size);
 
   // 여기서 전체 offset을 정리해서 두자.
   useEffect(() => {

--- a/src/app/timetable/components/CurrentTimeLine/index.tsx
+++ b/src/app/timetable/components/CurrentTimeLine/index.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 
 import styled from './CurrentTimeLine.module.scss';
-import { calculateCurrentTimeOffset, parseHeight, generateClassNameWithType } from '../../utils';
+import { calculateCurrentTimeOffset, parseSize, generateClassNameWithType } from '../../utils';
 import TypeContext from '../../TypeContext';
 
 interface CurrentTimeLineProps {
@@ -13,7 +13,7 @@ interface CurrentTimeLineProps {
 function CurrentTimeLine({ startTime, endTime, height }: CurrentTimeLineProps) {
   const type = useContext(TypeContext);
   const [currentTime, setCurrentTime] = useState(new Date());
-  const { value, format } = parseHeight(height);
+  const { value, format } = parseSize(height);
 
   // 여기서 전체 offset을 정리해서 두자.
   useEffect(() => {

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -49,13 +49,13 @@ function Timetable({
     { step: slotTime },
   );
   const { value, format } = parseHeight(height);
-  const slotHeight = distributeHeight(value, timeSlots.length, format);
+  const slotSize = distributeHeight(value, timeSlots.length, format);
 
   return (
     <TypeContext.Provider value={timetableType}>
       <TypeTimeTable
         timeSlots={timeSlots}
-        slotWidth={slotHeight}
+        slotSize={slotSize}
         taskList={taskList}
         slotTime={slotTime}
         displayCurrentTime={displayCurrentTime}

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -11,7 +11,7 @@ interface TimetableProps {
   startTime: Date;
   endTime: Date;
   slotTime: number;
-  height: string;
+  timeTableSize: string;
   timetableType: TimetableType;
   displayCurrentTime?: boolean;
   taskList: Task[];
@@ -24,7 +24,7 @@ function Timetable({
   startTime,
   endTime,
   slotTime,
-  height,
+  timeTableSize,
   timetableType,
   displayCurrentTime = false,
   taskList,
@@ -48,7 +48,7 @@ function Timetable({
     },
     { step: slotTime },
   );
-  const { value, format } = parseSize(height);
+  const { value, format } = parseSize(timeTableSize);
   const slotSize = distributeSize(value, timeSlots.length, format);
 
   return (
@@ -62,7 +62,7 @@ function Timetable({
         timeSlotStyle={timeSlotStyle}
         taskSlotStyle={taskSlotStyle}
         timeTableStyle={timeTableStyle}
-        height={height}
+        size={timeTableSize}
         startTime={startTime}
         endTime={endTime}
       />

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -32,12 +32,12 @@ function Timetable({
   timeSlotStyle = { color: 'black' },
   taskSlotStyle = { color: 'black' },
 }: TimetableProps) {
-  const hasOverlapFromTaskList = useCallback(
+  const checkOverlapFromTaskList = useCallback(
     (currentTaskList: Task[]) => checkTimeOverlapFromTaskList(currentTaskList),
     [taskList],
   );
 
-  if (hasOverlapFromTaskList(taskList)) {
+  if (checkOverlapFromTaskList(taskList)) {
     throw new Error('task time is overlap. please check your taskList');
   }
 

--- a/src/app/timetable/components/Timetable.tsx
+++ b/src/app/timetable/components/Timetable.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import { eachMinuteOfInterval } from 'date-fns';
-import { parseHeight, distributeHeight, checkTimeOverlapFromTaskList } from '../utils';
+import { parseSize, distributeSize, checkTimeOverlapFromTaskList } from '../utils';
 import { Task, TimetableType } from './Timetable.type';
 import TypeContext from '../TypeContext';
 import TypeTimeTable from './TypeTimeTable';
@@ -48,8 +48,8 @@ function Timetable({
     },
     { step: slotTime },
   );
-  const { value, format } = parseHeight(height);
-  const slotSize = distributeHeight(value, timeSlots.length, format);
+  const { value, format } = parseSize(height);
+  const slotSize = distributeSize(value, timeSlots.length, format);
 
   return (
     <TypeContext.Provider value={timetableType}>

--- a/src/app/timetable/components/TypeTimeTable/TaskSlot.tsx
+++ b/src/app/timetable/components/TypeTimeTable/TaskSlot.tsx
@@ -30,19 +30,23 @@ function TaskSlot({ headerDate, slotTime, taskItemList, shouldDisplayTaskContent
 
   return (
     <div className={generateClassNameWithType(styles, 'taskSlotLayout', type)} style={taskSlotStyle}>
-      {taskItemList.map((taskItem, index) => (
-        <TaskSlotItem
-          key={taskItem.id}
-          taskItem={taskItem}
-          index={index}
-          slotStartTime={slotStartTime}
-          slotEndTime={slotEndTime}
-          slotTime={slotTime}
-          shouldDisplayTaskContentList={shouldDisplayTaskContentList}
-          isOpen={openTaskIndex === index}
-          onOpenChange={(isOpen) => handleOpenChange(index, isOpen)}
-        />
-      ))}
+      {taskItemList.map((taskItem, index) => {
+        const shouldDisplayTaskContent = shouldDisplayTaskContentList[index];
+
+        return (
+          <TaskSlotItem
+            key={taskItem.id}
+            taskItem={taskItem}
+            index={index}
+            slotStartTime={slotStartTime}
+            slotEndTime={slotEndTime}
+            slotTime={slotTime}
+            shouldDisplayTaskContent={shouldDisplayTaskContent}
+            isOpen={openTaskIndex === index}
+            onOpenChange={(isOpen) => handleOpenChange(index, isOpen)}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/app/timetable/components/TypeTimeTable/TaskSlotItem.tsx
+++ b/src/app/timetable/components/TypeTimeTable/TaskSlotItem.tsx
@@ -9,7 +9,7 @@ import styles from './TypeTimeTable.module.scss';
 interface TaskSlotItemProps {
   taskItem: Task;
   index: number;
-  shouldDisplayTaskContentList: boolean[];
+  shouldDisplayTaskContent: boolean;
   slotStartTime: Date;
   slotEndTime: Date;
   slotTime: number;
@@ -19,8 +19,7 @@ interface TaskSlotItemProps {
 
 function TaskSlotItem({
   taskItem,
-  index,
-  shouldDisplayTaskContentList,
+  shouldDisplayTaskContent,
   slotStartTime,
   slotEndTime,
   slotTime,
@@ -57,7 +56,6 @@ function TaskSlotItem({
     slotTime,
   );
 
-  const shouldDisplayTaskContent = shouldDisplayTaskContentList[index];
   const taskSlotColor = taskColor ?? getColor(id);
   const positionStyles =
     type === 'ROW'

--- a/src/app/timetable/components/TypeTimeTable/index.tsx
+++ b/src/app/timetable/components/TypeTimeTable/index.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import Slot from './Slot';
 import { Task } from '../Timetable.type';
-import { generateClassNameWithType, hasKey, insertKey, taskListFilter } from '../../utils';
+import { generateClassNameWithType, hasKey, insertKey, filterTaskListByTimeSlot, isDateInRange } from '../../utils';
 import TypeContext from '../../TypeContext';
 import styles from './TypeTimeTable.module.scss';
 import CurrentTimeLine from '../CurrentTimeLine';
@@ -33,18 +33,16 @@ function TypeTimeTable({
   startTime,
   endTime,
 }: TypeTimeTableProps) {
-  const uniqueTaskIdMap = new Map();
   const type = useContext(TypeContext);
+  const uniqueTaskIdMap = new Map();
+  const isCurrentTimeVisible = displayCurrentTime && isDateInRange(timeSlots[0], new Date(), timeSlots[timeSlots.length - 1]);
 
-  const currentTime = new Date();
-
-  const isCurrentTimeVisible = timeSlots[0] <= currentTime && currentTime <= timeSlots[timeSlots.length - 1];
   return (
     <div className={generateClassNameWithType(styles, 'container', type)} style={timeTableStyle}>
-      {displayCurrentTime && isCurrentTimeVisible && <CurrentTimeLine startTime={startTime} endTime={endTime} size={size} />}
+      {isCurrentTimeVisible && <CurrentTimeLine startTime={startTime} endTime={endTime} size={size} />}
       {timeSlots.map((time, index) => {
         const key = `${time.toDateString()}${index}`;
-        const taskItemList = taskListFilter(taskList, time.getHours(), slotTime);
+        const taskItemList = filterTaskListByTimeSlot(taskList, time.getHours(), slotTime);
         const shouldDisplayTaskContentList: boolean[] = taskItemList.map((taskItem) => {
           const shouldDisplayTaskContent = !!(taskItem?.id && !hasKey(uniqueTaskIdMap, taskItem.id));
           insertKey(uniqueTaskIdMap, taskItem?.id, taskItem?.id);

--- a/src/app/timetable/components/TypeTimeTable/index.tsx
+++ b/src/app/timetable/components/TypeTimeTable/index.tsx
@@ -1,7 +1,14 @@
 import { useContext } from 'react';
 import Slot from './Slot';
 import { Task } from '../Timetable.type';
-import { generateClassNameWithType, hasKey, insertKey, filterTaskListByTimeSlot, isDateInRange } from '../../utils';
+import {
+  generateClassNameWithType,
+  hasKey,
+  insertKey,
+  filterTaskListByTimeSlot,
+  isDateInRange,
+  getShouldDisplayTaskContentList,
+} from '../../utils';
 import TypeContext from '../../TypeContext';
 import styles from './TypeTimeTable.module.scss';
 import CurrentTimeLine from '../CurrentTimeLine';
@@ -43,11 +50,7 @@ function TypeTimeTable({
       {timeSlots.map((time, index) => {
         const key = `${time.toDateString()}${index}`;
         const taskItemList = filterTaskListByTimeSlot(taskList, time.getHours(), slotTime);
-        const shouldDisplayTaskContentList: boolean[] = taskItemList.map((taskItem) => {
-          const shouldDisplayTaskContent = !!(taskItem?.id && !hasKey(uniqueTaskIdMap, taskItem.id));
-          insertKey(uniqueTaskIdMap, taskItem?.id, taskItem?.id);
-          return shouldDisplayTaskContent;
-        });
+        const shouldDisplayTaskContentList = getShouldDisplayTaskContentList(taskItemList, uniqueTaskIdMap);
 
         return (
           <Slot

--- a/src/app/timetable/components/TypeTimeTable/index.tsx
+++ b/src/app/timetable/components/TypeTimeTable/index.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import Slot from './Slot';
 import { Task } from '../Timetable.type';
-import { generateClassNameWithType, hasKey, insertKey } from '../../utils';
+import { generateClassNameWithType, hasKey, insertKey, taskListFilter } from '../../utils';
 import TypeContext from '../../TypeContext';
 import styles from './TypeTimeTable.module.scss';
 import CurrentTimeLine from '../CurrentTimeLine';
@@ -19,19 +19,6 @@ interface TypeTimeTableProps {
   taskSlotStyle?: React.CSSProperties;
   timeTableStyle?: React.CSSProperties;
 }
-
-const taskListFilter = (taskListInput: Task[], checkHour: number, slotTimeInput: number) =>
-  taskListInput.filter((task: Task) => {
-    const taskStartHour = task.startTime.getHours();
-    const taskEndHour = task.endTime.getHours();
-    const taskEndMinute = task.endTime.getMinutes();
-
-    return (
-      taskStartHour <= checkHour &&
-      taskEndHour >= checkHour &&
-      !(taskEndHour === checkHour && taskEndMinute === slotTimeInput % 60)
-    );
-  });
 
 function TypeTimeTable({
   timeSlots,

--- a/src/app/timetable/components/TypeTimeTable/index.tsx
+++ b/src/app/timetable/components/TypeTimeTable/index.tsx
@@ -11,7 +11,7 @@ interface TypeTimeTableProps {
   slotSize: string;
   taskList: Task[];
   slotTime: number;
-  height: string;
+  size: string;
   startTime: Date;
   endTime: Date;
   displayCurrentTime?: boolean;
@@ -29,7 +29,7 @@ function TypeTimeTable({
   displayCurrentTime,
   taskSlotStyle = {},
   timeTableStyle = {},
-  height,
+  size,
   startTime,
   endTime,
 }: TypeTimeTableProps) {
@@ -41,7 +41,7 @@ function TypeTimeTable({
   const isCurrentTimeVisible = timeSlots[0] <= currentTime && currentTime <= timeSlots[timeSlots.length - 1];
   return (
     <div className={generateClassNameWithType(styles, 'container', type)} style={timeTableStyle}>
-      {displayCurrentTime && isCurrentTimeVisible && <CurrentTimeLine startTime={startTime} endTime={endTime} height={height} />}
+      {displayCurrentTime && isCurrentTimeVisible && <CurrentTimeLine startTime={startTime} endTime={endTime} size={size} />}
       {timeSlots.map((time, index) => {
         const key = `${time.toDateString()}${index}`;
         const taskItemList = taskListFilter(taskList, time.getHours(), slotTime);

--- a/src/app/timetable/components/TypeTimeTable/index.tsx
+++ b/src/app/timetable/components/TypeTimeTable/index.tsx
@@ -1,14 +1,7 @@
 import { useContext } from 'react';
 import Slot from './Slot';
 import { Task } from '../Timetable.type';
-import {
-  generateClassNameWithType,
-  hasKey,
-  insertKey,
-  filterTaskListByTimeSlot,
-  isDateInRange,
-  getShouldDisplayTaskContentList,
-} from '../../utils';
+import { generateClassNameWithType, filterTaskListByTimeSlot, isDateInRange, getShouldDisplayTaskContentList } from '../../utils';
 import TypeContext from '../../TypeContext';
 import styles from './TypeTimeTable.module.scss';
 import CurrentTimeLine from '../CurrentTimeLine';

--- a/src/app/timetable/components/TypeTimeTable/index.tsx
+++ b/src/app/timetable/components/TypeTimeTable/index.tsx
@@ -8,7 +8,7 @@ import CurrentTimeLine from '../CurrentTimeLine';
 
 interface TypeTimeTableProps {
   timeSlots: Date[];
-  slotWidth: string;
+  slotSize: string;
   taskList: Task[];
   slotTime: number;
   height: string;
@@ -22,7 +22,7 @@ interface TypeTimeTableProps {
 
 function TypeTimeTable({
   timeSlots,
-  slotWidth,
+  slotSize,
   timeSlotStyle,
   taskList,
   slotTime,
@@ -55,7 +55,7 @@ function TypeTimeTable({
           <Slot
             key={key}
             headerDate={time}
-            size={slotWidth}
+            size={slotSize}
             timeSlotStyle={timeSlotStyle}
             shouldDisplayTaskContentList={shouldDisplayTaskContentList}
             slotTime={slotTime}

--- a/src/app/timetable/page.tsx
+++ b/src/app/timetable/page.tsx
@@ -12,7 +12,7 @@ export default function TimetablePage() {
           endTime={endTime}
           slotTime={slotTime}
           taskList={taskList}
-          height="2000px"
+          timeTableSize="2000px"
           timetableType="ROW"
           displayCurrentTime
           timeTableStyle={{ backgroundColor: 'white' }}
@@ -26,7 +26,7 @@ export default function TimetablePage() {
           endTime={endTime}
           slotTime={slotTime}
           taskList={taskList}
-          height="2000px"
+          timeTableSize="2000px"
           timetableType="COLUMN"
           displayCurrentTime
           timeTableStyle={{ backgroundColor: 'white' }}

--- a/src/app/timetable/utils/height.ts
+++ b/src/app/timetable/utils/height.ts
@@ -2,8 +2,8 @@ import { FORMAT_LIST, FormatType } from '../constants';
 
 const isFormatString = (formatType: string): formatType is FormatType => FORMAT_LIST.includes(formatType as FormatType);
 
-const parseHeightFormat = (heightWithFormat: string) => {
-  const formatList = heightWithFormat.match(/[a-z%]+/);
+const parseSizeFormat = (sizeWithFormat: string) => {
+  const formatList = sizeWithFormat.match(/[a-z%]+/);
 
   if (!formatList || formatList.length >= 2) {
     throw new Error('Unsupported format');
@@ -18,8 +18,8 @@ const parseHeightFormat = (heightWithFormat: string) => {
   return format;
 };
 
-const parseHeightValue = (heightWithFormat: string) => {
-  const value = parseFloat(heightWithFormat);
+const parseSizeValue = (sizeWithFormat: string) => {
+  const value = parseFloat(sizeWithFormat);
 
   if (Number.isNaN(value)) {
     throw new Error('No numeric value found in input');
@@ -28,24 +28,24 @@ const parseHeightValue = (heightWithFormat: string) => {
   return value;
 };
 
-const parseHeight = (heightWithFormat: string) => {
-  const format = parseHeightFormat(heightWithFormat);
-  const value = parseHeightValue(heightWithFormat);
+const parseSize = (sizeWithFormat: string) => {
+  const format = parseSizeFormat(sizeWithFormat);
+  const value = parseSizeValue(sizeWithFormat);
 
   return { value, format };
 };
 
-const distributeHeight = (totalHeight: number, length: number, format: string = 'px') => {
+const distributeSize = (totalSize: number, length: number, format: string = 'px') => {
   if (!isFormatString(format)) {
     throw new Error('wrong format');
   }
 
-  if (length === 0 || totalHeight <= 0) {
+  if (length === 0 || totalSize <= 0) {
     throw new Error('wrong number');
   }
 
-  const height = totalHeight / length;
-  return `${height}${format}`;
+  const size = totalSize / length;
+  return `${size}${format}`;
 };
 
-export { distributeHeight, isFormatString, parseHeight, parseHeightFormat, parseHeightValue };
+export { distributeSize, isFormatString, parseSize, parseSizeFormat, parseSizeValue };

--- a/src/app/timetable/utils/index.ts
+++ b/src/app/timetable/utils/index.ts
@@ -98,18 +98,20 @@ const calculateCurrentTimeOffset = (currentTime: Date, startTime: Date, endTime:
   return { offsetPercent };
 };
 
-const taskListFilter = (taskListInput: Task[], checkHour: number, slotTimeInput: number) =>
+const filterTaskListByTimeSlot = (taskListInput: Task[], slotStartHour: number, slotMinutes: number) =>
   taskListInput.filter((task: Task) => {
     const taskStartHour = task.startTime.getHours();
     const taskEndHour = task.endTime.getHours();
     const taskEndMinute = task.endTime.getMinutes();
 
     return (
-      taskStartHour <= checkHour &&
-      taskEndHour >= checkHour &&
-      !(taskEndHour === checkHour && taskEndMinute === slotTimeInput % 60)
+      taskStartHour <= slotStartHour &&
+      taskEndHour >= slotStartHour &&
+      !(taskEndHour === slotStartHour && taskEndMinute === slotMinutes % 60)
     );
   });
+
+const isDateInRange = (startDate: Date, date: Date, endDate: Date) => startDate <= date && date <= endDate;
 
 export {
   getHourAndMinutesFormat,
@@ -119,7 +121,8 @@ export {
   getDateFromTime,
   checkTimeOverlapFromTaskList,
   calculateCurrentTimeOffset,
-  taskListFilter,
+  filterTaskListByTimeSlot,
+  isDateInRange,
 };
 
 export { hasKey, insertKey } from './map';

--- a/src/app/timetable/utils/index.ts
+++ b/src/app/timetable/utils/index.ts
@@ -113,6 +113,15 @@ const filterTaskListByTimeSlot = (taskListInput: Task[], slotStartHour: number, 
 
 const isDateInRange = (startDate: Date, date: Date, endDate: Date) => startDate <= date && date <= endDate;
 
+const getShouldDisplayTaskContentList = (taskItemList: Task[], uniqueTaskIdMap: Map<unknown, unknown>): boolean[] =>
+  taskItemList.map((taskItem) => {
+    const shouldDisplayTaskContent = !!(taskItem?.id && !uniqueTaskIdMap.has(taskItem.id));
+    if (taskItem?.id) {
+      uniqueTaskIdMap.set(taskItem.id, taskItem.id);
+    }
+    return shouldDisplayTaskContent;
+  });
+
 export {
   getHourAndMinutesFormat,
   sumHoursAndMinutes,
@@ -123,6 +132,7 @@ export {
   calculateCurrentTimeOffset,
   filterTaskListByTimeSlot,
   isDateInRange,
+  getShouldDisplayTaskContentList,
 };
 
 export { hasKey, insertKey } from './map';

--- a/src/app/timetable/utils/index.ts
+++ b/src/app/timetable/utils/index.ts
@@ -123,6 +123,6 @@ export {
 };
 
 export { hasKey, insertKey } from './map';
-export { distributeHeight, isFormatString, parseHeight, parseHeightFormat, parseHeightValue } from './height';
+export { distributeSize, isFormatString, parseSize, parseSizeFormat, parseSizeValue } from './height';
 export { getColor } from './color';
 export { generateClassNameWithType } from './css';

--- a/src/app/timetable/utils/index.ts
+++ b/src/app/timetable/utils/index.ts
@@ -98,6 +98,19 @@ const calculateCurrentTimeOffset = (currentTime: Date, startTime: Date, endTime:
   return { offsetPercent };
 };
 
+const taskListFilter = (taskListInput: Task[], checkHour: number, slotTimeInput: number) =>
+  taskListInput.filter((task: Task) => {
+    const taskStartHour = task.startTime.getHours();
+    const taskEndHour = task.endTime.getHours();
+    const taskEndMinute = task.endTime.getMinutes();
+
+    return (
+      taskStartHour <= checkHour &&
+      taskEndHour >= checkHour &&
+      !(taskEndHour === checkHour && taskEndMinute === slotTimeInput % 60)
+    );
+  });
+
 export {
   getHourAndMinutesFormat,
   sumHoursAndMinutes,
@@ -106,6 +119,7 @@ export {
   getDateFromTime,
   checkTimeOverlapFromTaskList,
   calculateCurrentTimeOffset,
+  taskListFilter,
 };
 
 export { hasKey, insertKey } from './map';

--- a/src/app/timetable/utils/tests/parseHeightString.test.ts
+++ b/src/app/timetable/utils/tests/parseHeightString.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { parseHeightFormat, parseHeightValue } from '..';
+import { parseSizeFormat, parseSizeValue } from '..';
 import { FORMAT_LIST } from '../../constants';
 
 describe('Timetable의 height 값 나누기', () => {
@@ -12,7 +12,7 @@ describe('Timetable의 height 값 나누기', () => {
         const heightString = `${height}${format}`;
 
         // when
-        const result = parseHeightFormat(heightString);
+        const result = parseSizeFormat(heightString);
 
         // then
         expect(result).toEqual(format);
@@ -28,7 +28,7 @@ describe('Timetable의 height 값 나누기', () => {
         const height = `${heightValue}${format}`;
         test(`height으로 ${height}이 주어졌을 때 값 ${heightValue}을 분리할 수 있다.`, () => {
           // when
-          const result = parseHeightValue(height);
+          const result = parseSizeValue(height);
           // then
           expect(result).toEqual(heightValue);
         });

--- a/src/app/timetable/utils/tests/parseHeightString.test.ts
+++ b/src/app/timetable/utils/tests/parseHeightString.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, test } from '@jest/globals';
 import { parseSizeFormat, parseSizeValue } from '..';
 import { FORMAT_LIST } from '../../constants';
 
-describe('Timetable의 height 값 나누기', () => {
-  describe('height 값에서 format 가져오기', () => {
-    const height = 1000;
+describe('Timetable의 size 값 나누기', () => {
+  describe('size 값에서 format 가져오기', () => {
+    const size = 1000;
 
     FORMAT_LIST.forEach((format) => {
-      test(`height으로 ${height}${format} 이 주어졌을 때 ${format}을 분리할 수 있다.`, () => {
+      test(`size으로 ${size}${format} 이 주어졌을 때 ${format}을 분리할 수 있다.`, () => {
         // given
-        const heightString = `${height}${format}`;
+        const sizeString = `${size}${format}`;
 
         // when
-        const result = parseSizeFormat(heightString);
+        const result = parseSizeFormat(sizeString);
 
         // then
         expect(result).toEqual(format);
@@ -20,17 +20,17 @@ describe('Timetable의 height 값 나누기', () => {
     });
   });
 
-  describe('height 값에서 value 가져오기', () => {
-    const heightValueList = [100, 95, 0.5, 48.33333, 3];
+  describe('size 값에서 value 가져오기', () => {
+    const sizeValueList = [100, 95, 0.5, 48.33333, 3];
 
-    heightValueList.forEach((heightValue) => {
+    sizeValueList.forEach((sizeValue) => {
       FORMAT_LIST.forEach((format) => {
-        const height = `${heightValue}${format}`;
-        test(`height으로 ${height}이 주어졌을 때 값 ${heightValue}을 분리할 수 있다.`, () => {
+        const size = `${sizeValue}${format}`;
+        test(`size으로 ${size}이 주어졌을 때 값 ${sizeValue}을 분리할 수 있다.`, () => {
           // when
-          const result = parseSizeValue(height);
+          const result = parseSizeValue(size);
           // then
-          expect(result).toEqual(heightValue);
+          expect(result).toEqual(sizeValue);
         });
       });
     });

--- a/src/app/timetable/utils/timeTable.util.test.ts
+++ b/src/app/timetable/utils/timeTable.util.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 import { FORMAT_LIST } from '../constants';
-import { parseHeightFormat, parseHeightValue } from './height';
+import { parseSizeFormat, parseSizeValue } from './height';
 
 describe('Timetable의 height 값 나누기', () => {
   describe('height 값에서 format 가져오기', () => {
@@ -12,7 +12,7 @@ describe('Timetable의 height 값 나누기', () => {
         const heightString = `${height}${format}`;
 
         // when
-        const result = parseHeightFormat(heightString);
+        const result = parseSizeFormat(heightString);
 
         // then
         expect(result).toEqual(format);
@@ -28,7 +28,7 @@ describe('Timetable의 height 값 나누기', () => {
         const height = `${heightValue}${format}`;
         test(`height으로 ${height}이 주어졌을 때 값 ${heightValue}을 분리할 수 있다.`, () => {
           // when
-          const result = parseHeightValue(height);
+          const result = parseSizeValue(height);
           // then
           expect(result).toEqual(heightValue);
         });


### PR DESCRIPTION
- Close #73 

## What is this PR? 🔍

- 기능 :
현재 타임테이블 컴포넌트의 height으로 지정된 값을 size로 변경합니다. 이유는 row type일 때, height이 아닌 width가 적용되기때문에 공통적으로 길이를 나타내는 말을 넣어야합니다.
가능하다면 가독성 향상을 위해 함수는 컴포넌트에서 분리합니다.
- issue : #73 

## Changes 📝
- height을 size로 변경했습니다.
- 함수와 컴포넌트를 분리했습니다.
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
