### PR TITLE
feat: timetable 어플리케이션에 병합

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,8 @@
     "plugin:jsx-a11y/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript"
+    "plugin:import/typescript",
+    "plugin:prettier/recommended" // prettier 설정 추가
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -23,7 +24,7 @@
     "sourceType": "module",
     "project": "./tsconfig.json"
   },
-  "plugins": ["react", "@typescript-eslint", "jsx-a11y", "import"],
+  "plugins": ["react", "@typescript-eslint", "jsx-a11y", "import", "prettier"],
   "rules": {
     "react/react-in-jsx-scope": "off",
     "import/prefer-default-export": "off", //파일에서 export를 하나만 할때 default export를 쓰라고 하는 eslint off

--- a/src/app/MainTest/page.tsx
+++ b/src/app/MainTest/page.tsx
@@ -3,12 +3,12 @@
 import React from 'react';
 import Todo from '@/components/todo';
 import { BasicContainer } from '@/components/common';
-
+import TimeTable from '@/components/TimeTable';
 
 export default function mainTestPage() {
   return (
     <BasicContainer>
-      <div>타임테이블 영역</div>
+      <TimeTable />
       <Todo />
     </BasicContainer>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import AuthProvider from '@/components/common/AuthProvider';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 
-
 export const metadata: Metadata = {
   title: 'sumday',
   description: 'kernel FE E2E project',

--- a/src/app/timetable/components/TypeTimeTable/TaskSlotItem.tsx
+++ b/src/app/timetable/components/TypeTimeTable/TaskSlotItem.tsx
@@ -30,7 +30,7 @@ function TaskSlotItem({
   const { startTime, endTime, taskColor, title, subTitle, id } = taskItem;
   const taskSlotRef = useRef<HTMLDivElement>(null);
   const [isContentVisible, setIsContentVisible] = useState(false);
-
+  const defaultValue = '...'; // 이 부분이 이후에 Props로 전달 받아서 표현 될 내용이다.
   const type = useContext(TypeContext);
 
   const {
@@ -69,18 +69,24 @@ function TaskSlotItem({
   const floatingPositionStyles = type === 'ROW' ? { left: `${offsetPercent}%` } : { top: `${offsetPercent}%` };
 
   useEffect(() => {
-    if (taskSlotRef.current) {
-      const height = taskSlotRef.current.offsetHeight;
-      setIsContentVisible(height > 40);
+    if (type === 'ROW') {
+      if (taskSlotRef.current) {
+        const width = taskSlotRef.current.offsetWidth;
+        setIsContentVisible(width > 40);
+      }
     }
-  }, [taskSlotRef.current]);
-
+    if (type === 'COLUMN') {
+      if (taskSlotRef.current) {
+        const height = taskSlotRef.current.offsetHeight;
+        setIsContentVisible(height > 40);
+      }
+    }
+  }, [taskSlotRef.current, type]);
   return (
     <div>
       <button
         type="button"
         ref={ref}
-        // ref={taskSlotRef}
         {...props}
         className={generateClassNameWithType(styles, 'buttonInherit', type)}
         style={{
@@ -89,11 +95,17 @@ function TaskSlotItem({
         }}
       >
         <div ref={taskSlotRef} className={generateClassNameWithType(styles, 'taskSlotBackground', type)}>
-          {isContentVisible &&
-            shouldDisplayTaskContent && ( // taskSlotContent
+          {shouldDisplayTaskContent &&
+            isContentVisible && ( // taskSlotContent
               <div className={generateClassNameWithType(styles, 'taskSlotContent', type)}>
                 <p className={generateClassNameWithType(styles, 'title', type)}>{title}</p>
                 <p className={generateClassNameWithType(styles, 'description', type)}>{subTitle}</p>
+              </div>
+            )}
+          {shouldDisplayTaskContent &&
+            !isContentVisible && ( // taskSlotContent
+              <div className={generateClassNameWithType(styles, 'taskSlotContent', type)}>
+                <p className={generateClassNameWithType(styles, 'title', type)}>{defaultValue}</p>
               </div>
             )}
         </div>

--- a/src/app/timetable/components/TypeTimeTable/TaskSlotItem.tsx
+++ b/src/app/timetable/components/TypeTimeTable/TaskSlotItem.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useContext } from 'react';
+import React, { useContext, useRef, useEffect, useState } from 'react';
 import { flip, offset, useClick, useDismiss, useFloating, useInteractions, useMergeRefs } from '@floating-ui/react';
 import { calculateTaskOffsetAndHeightPercent, getColor, generateClassNameWithType } from '../../utils';
 import { Task } from '../Timetable.type';
@@ -28,6 +28,9 @@ function TaskSlotItem({
   onOpenChange,
 }: TaskSlotItemProps) {
   const { startTime, endTime, taskColor, title, subTitle, id } = taskItem;
+  const taskSlotRef = useRef<HTMLDivElement>(null);
+  const [isContentVisible, setIsContentVisible] = useState(false);
+
   const type = useContext(TypeContext);
 
   const {
@@ -65,11 +68,19 @@ function TaskSlotItem({
       : { top: `${offsetPercent}%`, left: '0', height: `${heightPercent}%` };
   const floatingPositionStyles = type === 'ROW' ? { left: `${offsetPercent}%` } : { top: `${offsetPercent}%` };
 
+  useEffect(() => {
+    if (taskSlotRef.current) {
+      const height = taskSlotRef.current.offsetHeight;
+      setIsContentVisible(height > 40);
+    }
+  }, [taskSlotRef.current]);
+
   return (
     <div>
       <button
         type="button"
         ref={ref}
+        // ref={taskSlotRef}
         {...props}
         className={generateClassNameWithType(styles, 'buttonInherit', type)}
         style={{
@@ -77,13 +88,14 @@ function TaskSlotItem({
           backgroundColor: `${taskSlotColor}`,
         }}
       >
-        <div className={generateClassNameWithType(styles, 'taskSlotBackground', type)}>
-          {shouldDisplayTaskContent && ( // taskSlotContent
-            <div className={generateClassNameWithType(styles, 'taskSlotContent', type)}>
-              <p className={generateClassNameWithType(styles, 'title', type)}>{title}</p>
-              <p className={generateClassNameWithType(styles, 'description', type)}>{subTitle}</p>
-            </div>
-          )}
+        <div ref={taskSlotRef} className={generateClassNameWithType(styles, 'taskSlotBackground', type)}>
+          {isContentVisible &&
+            shouldDisplayTaskContent && ( // taskSlotContent
+              <div className={generateClassNameWithType(styles, 'taskSlotContent', type)}>
+                <p className={generateClassNameWithType(styles, 'title', type)}>{title}</p>
+                <p className={generateClassNameWithType(styles, 'description', type)}>{subTitle}</p>
+              </div>
+            )}
         </div>
       </button>
       {shouldDisplayTaskContent && isOpen && (

--- a/src/app/timetable/components/TypeTimeTable/TypeTimeTable.module.scss
+++ b/src/app/timetable/components/TypeTimeTable/TypeTimeTable.module.scss
@@ -3,6 +3,7 @@
   position: relative;
   height: 100%;
   width: 100%;
+  padding-top: 10px;
 
   &.row {
     flex-direction: row;

--- a/src/app/timetable/components/TypeTimeTable/TypeTimeTable.module.scss
+++ b/src/app/timetable/components/TypeTimeTable/TypeTimeTable.module.scss
@@ -62,7 +62,7 @@
   container: taskSlot / size;
   width: 100%;
   top: 0;
-  height: 100%; //얘를 넘겨줘야 ref 로 height 값을 받아오고 그것으로 높이에 따라서 렌더링을 달리 할 수 있음.
+  height: 100%;
   &.row {
     height: 100%;
   }

--- a/src/app/timetable/components/TypeTimeTable/TypeTimeTable.module.scss
+++ b/src/app/timetable/components/TypeTimeTable/TypeTimeTable.module.scss
@@ -62,12 +62,13 @@
   container: taskSlot / size;
   width: 100%;
   top: 0;
-
+  height: 100%; //얘를 넘겨줘야 ref 로 height 값을 받아오고 그것으로 높이에 따라서 렌더링을 달리 할 수 있음.
   &.row {
     height: 100%;
   }
 
   &.col {
+    height: 100%;
     @container taskSlot (height < 40px) {
       & .taskSlotContent {
         flex-direction: row;

--- a/src/components/TimeTable/TimeTable.styled.ts
+++ b/src/components/TimeTable/TimeTable.styled.ts
@@ -3,7 +3,5 @@ import styled from '@emotion/styled';
 export const TimeTableSection = styled.div`
   padding: 20px 20px 0px;
   width: 50%;
-
-  /* width: 100%; // 이건 COLUMN일 때 */
-  height: 100%; // 이건 COLUMN일 때
+  height: 100%;
 `;

--- a/src/components/TimeTable/TimeTable.styled.ts
+++ b/src/components/TimeTable/TimeTable.styled.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+export const TimeTableSection = styled.div`
+  padding: 20px;
+  width: 50%;
+  height: 484px;
+  /* width: 100%; // 이건 COLUMN일 때 */
+  /* height: 100%; // 이건 COLUMN일 때 */
+`;

--- a/src/components/TimeTable/TimeTable.styled.ts
+++ b/src/components/TimeTable/TimeTable.styled.ts
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
 export const TimeTableSection = styled.div`
-  padding: 20px;
+  padding: 20px 20px 0px;
   width: 50%;
-  height: 484px;
+
   /* width: 100%; // 이건 COLUMN일 때 */
-  /* height: 100%; // 이건 COLUMN일 때 */
+  height: 100%; // 이건 COLUMN일 때
 `;

--- a/src/components/TimeTable/index.tsx
+++ b/src/components/TimeTable/index.tsx
@@ -12,7 +12,7 @@ function TimeTable() {
         endTime={endTime}
         slotTime={60}
         taskList={taskListWithouttaskColor}
-        height="2000px"
+        timeTableSize="2000px"
         timetableType="COLUMN"
         displayCurrentTime
       />

--- a/src/components/TimeTable/index.tsx
+++ b/src/components/TimeTable/index.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import Timetable from '@/app/timetable/components/Timetable';
+import * as S from './TimeTable.styled';
+import { taskListWithouttaskColor, startTime, endTime } from '../../app/timetable/mocks/timetableMockData';
+
+function TimeTable() {
+  return (
+    <S.TimeTableSection>
+      <Timetable
+        startTime={startTime}
+        endTime={endTime}
+        slotTime={60}
+        taskList={taskListWithouttaskColor}
+        height="2000px"
+        timetableType="COLUMN"
+        displayCurrentTime
+      />
+    </S.TimeTableSection>
+  );
+}
+
+export default TimeTable;

--- a/src/components/todo/Todo.styled.ts
+++ b/src/components/todo/Todo.styled.ts
@@ -9,6 +9,7 @@ export const TodoSection = styled(Flex)`
   background-color: whitesmoke;
   border-radius: 5px;
   position: relative;
+  padding: 20px;
 `;
 
 export const TodoComponentsSection = styled(Container)`
@@ -22,7 +23,7 @@ export const TodoComponentsSection = styled(Container)`
   overflow-y: auto; /* scrolling */
   border-radius: 5px;
   border: 1px solid red;
-  margin: 10px;
+
   padding: 10px;
   border-style: none;
   position: relative;


### PR DESCRIPTION
- Close #71 

## What is this PR? 🔍

- 기능 : 라이브러리로 분리될 TimeTable 컴포넌트를 mock데이터를 활용하여 mainTest 페이지에 병합하였습니다.
- issue : #71 

## Changes 📝

* MainPage에서 TimeTable 렌더링( mock 데이터 활용)
* task slot 40px 이하일 때, title, subTitle 등 렌더링 되지 않게 구현
 
<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷
![image](https://github.com/user-attachments/assets/a05fbd1c-3f29-4d53-86e7-158cff6c20f5)
![Aug-07-2024 12-06-22](https://github.com/user-attachments/assets/e4c11948-ed2a-47f5-b8bb-67083ad59ab1)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

1. MainPage에 있던 Todo쪽 컴포넌트의 margin, padding 부분을 조금 수정하였습니다. 충돌 나시면 제 브렌치 것을 가져가시고, dev에서 깨지지 않는지 확인 한번 부탁드립니다.

2. 현재 추가적으로 Timetable 개발 수정 요소가 존재합니다.
  * currentTimeLine 디자인 수정 관련 Props 추가
  * task slot 작을 때, 표현 될, defaulValue Props 추가
  * task slot Hover 기능 Props 추가

  위와 관련된 내용은 노션의 `[타임테이블]` 페이지에서 확인 하실 수 있으며, 해당 개발이 완료 후, 컴포넌트 사용 문서도 업데이트 될 예정입니다. (현재는 24.08.06일 작성 버전입니다.)


<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
