### PR TITLE
fix: todo 제거 후 다시 생성한 후 해당 todo를 열면 modal에 제거되었던 todo가 표시되는 문제를 해결했습니다.

### DIFF
--- a/src/components/todo/TodoModal.tsx
+++ b/src/components/todo/TodoModal.tsx
@@ -18,7 +18,7 @@ interface TodoModalProps {
 }
 
 export default function TodoModal({ open, todoId, isModalOpenedByFAB, setIsModalOpenFalse }: TodoModalProps) {
-  const { data: todoData } = useGetOneTodo(todoId);
+  const { data: todoData, isSuccess: isSuccessGetOneTodo } = useGetOneTodo(todoId);
   const [title, setTitle] = React.useState('');
   const [content, setContent] = React.useState('');
   const [startTime, setStartTime] = React.useState('');
@@ -97,30 +97,38 @@ export default function TodoModal({ open, todoId, isModalOpenedByFAB, setIsModal
   };
 
   return (
-    <Modal open={open} onClose={handleCloseModal} aria-labelledby="modal-title" aria-describedby="modal-description">
-      <Box sx={TodoModalStyle}>
-        <Box display="flex" justifyContent="space-between" alignItems="center">
-          <Typography id="modal-title" variant="h6" component="h2">
-            {isModalOpenedByFAB ? 'Todo 생성' : 'Todo 수정'}
-          </Typography>
-          {!isModalOpenedByFAB && (
-            <IconButton onClick={handleDelete} color="secondary">
-              <DeleteIcon />
-            </IconButton>
-          )}
+    (isModalOpenedByFAB || isSuccessGetOneTodo) && (
+      <Modal open={open} onClose={handleCloseModal} aria-labelledby="modal-title" aria-describedby="modal-description">
+        <Box sx={TodoModalStyle}>
+          <Box display="flex" justifyContent="space-between" alignItems="center">
+            <Typography id="modal-title" variant="h6" component="h2">
+              {isModalOpenedByFAB ? 'Todo 생성' : 'Todo 수정'}
+            </Typography>
+            {!isModalOpenedByFAB && (
+              <IconButton onClick={handleDelete} color="secondary">
+                <DeleteIcon />
+              </IconButton>
+            )}
+          </Box>
+          <TextField fullWidth margin="normal" label="제목" value={title} onChange={(e) => setTitle(e.target.value)} />
+          <TextField fullWidth margin="normal" label="설명" value={content} onChange={(e) => setContent(e.target.value)} />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="시작 시간"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+          />
+          <TextField fullWidth margin="normal" label="종료 시간" value={endTime} onChange={(e) => setEndTime(e.target.value)} />
+          <TextField fullWidth margin="normal" label="색" value={color} onChange={(e) => setColor(e.target.value)} />
+          <Button onClick={isModalOpenedByFAB ? handleCreateTodo : handleUpdateTodo} variant="contained" color="primary">
+            저장
+          </Button>
+          <Button onClick={handleCloseModal} variant="outlined" color="secondary" sx={{ ml: 2 }}>
+            취소
+          </Button>
         </Box>
-        <TextField fullWidth margin="normal" label="제목" value={title} onChange={(e) => setTitle(e.target.value)} />
-        <TextField fullWidth margin="normal" label="설명" value={content} onChange={(e) => setContent(e.target.value)} />
-        <TextField fullWidth margin="normal" label="시작 시간" value={startTime} onChange={(e) => setStartTime(e.target.value)} />
-        <TextField fullWidth margin="normal" label="종료 시간" value={endTime} onChange={(e) => setEndTime(e.target.value)} />
-        <TextField fullWidth margin="normal" label="색" value={color} onChange={(e) => setColor(e.target.value)} />
-        <Button onClick={isModalOpenedByFAB ? handleCreateTodo : handleUpdateTodo} variant="contained" color="primary">
-          저장
-        </Button>
-        <Button onClick={handleCloseModal} variant="outlined" color="secondary" sx={{ ml: 2 }}>
-          취소
-        </Button>
-      </Box>
-    </Modal>
+      </Modal>
+    )
   );
 }

--- a/src/components/todo/TodoModal.tsx
+++ b/src/components/todo/TodoModal.tsx
@@ -52,8 +52,8 @@ export default function TodoModal({ open, todoId, isModalOpenedByFAB, setIsModal
     setIsModalOpenFalse();
   };
 
-  const handleUpdateTodo = () => {
-    updateTodo(
+  const handleUpdateTodo = async () => {
+    await updateTodo(
       { todoId, title, content, startTime, endTime, color },
       {
         onSuccess: () => {
@@ -68,8 +68,8 @@ export default function TodoModal({ open, todoId, isModalOpenedByFAB, setIsModal
     );
   };
 
-  const handleCreateTodo = () => {
-    createTodo(
+  const handleCreateTodo = async () => {
+    await createTodo(
       { userId: 1, title, content, startTime, endTime, color },
       {
         onSuccess: () => {
@@ -83,14 +83,14 @@ export default function TodoModal({ open, todoId, isModalOpenedByFAB, setIsModal
     );
   };
 
-  const handleDelete = () => {
-    deleteTodo(todoId, {
+  const handleDelete = async () => {
+    await deleteTodo(todoId, {
       onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['todo', todoId] });
         queryClient.invalidateQueries({ queryKey: ['todos', 1] });
         handleCloseModal();
       },
       onError: (error) => {
-        queryClient.invalidateQueries({ queryKey: ['todos', 1] });
         alert(`Todo를 삭제하는 데 실패했습니다.${error}`);
       },
     });


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍

- 기능 :todo 제거 후 다시 생성한 후 해당 todo를 열면 modal에 제거되었던 todo가 표시되는 문제를 해결했습니다.
- issue : #98 

## Changes 📝

### 변경 전
- todo를 제거 후 그 자리에 새롭게 생성하면 과거 해당 자리에 있었던 todo가 modal에 표시되는 문제가 있었습니다.
- 동일 작업을 했을 때, 과거 내용이 잠시 보였다가 사라지는 문제가 있었습니다.
### 변경 후
- 비동기 처리를 통해 삭제 시 invalidateQueries()가 정상적으로 실행되도록 수정했습니다.
- 조건부 렌더링을 통해 modal을 열 때, 빈 데이터 또는 과거 데이터가 잠시 표시되는 문제를 방지하였습니다.

## ScreenShot 📷

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
